### PR TITLE
perf(pencil): remove graphiteWidth option  BREAKING CHANGE: The graph…

### DIFF
--- a/Readme
+++ b/Readme
@@ -4,3 +4,4 @@ primer com
 
 
 
+HGJJHGJHGJJ


### PR DESCRIPTION
…iteWidth option has been removed. The default graphite width of 10mm is always used for performance reasons.